### PR TITLE
integrating mean ablation into existing evaluate_graph code

### DIFF
--- a/mean_ablate.ipynb
+++ b/mean_ablate.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/Ubuntu/miniconda3/envs/formal_functional/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "from functools import partial\n",
+    "\n",
+    "import torch\n",
+    "from torch.utils.data import DataLoader\n",
+    "from transformer_lens import HookedTransformer\n",
+    "from datasets import load_dataset\n",
+    "\n",
+    "from graph import Graph\n",
+    "from gt_dataset import EAPDataset\n",
+    "from attribute import attribute\n",
+    "from metrics import get_metric\n",
+    "from evaluate_graph import evaluate_graph, evaluate_baseline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded pretrained model gpt2-small into HookedTransformer\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = HookedTransformer.from_pretrained(\"gpt2-small\", device=\"cuda\")\n",
+    "model.cfg.use_split_qkv_input = True\n",
+    "model.cfg.use_attn_result = True\n",
+    "model.cfg.use_hook_mlp_in = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = EAPDataset(\"greater-than-gpt2.csv\")\n",
+    "dataloader = dataset.to_dataloader(64)\n",
+    "metric_fn = get_metric(\"prob_diff\", \"greater-than\", model.tokenizer, model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 16/16 [00:11<00:00,  1.42it/s]\n",
+      "100%|██████████| 32491/32491 [00:00<00:00, 87434.82it/s] \n",
+      "100%|██████████| 16/16 [00:02<00:00,  7.55it/s]\n",
+      "100%|██████████| 16/16 [00:01<00:00, 14.27it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Faithfulness: 0.923550694404797\n"
+     ]
+    }
+   ],
+   "source": [
+    "g = Graph.from_model(model)\n",
+    "attribute(model, g, dataloader, partial(metric_fn, loss=True, mean=True), integrated_gradients=5)\n",
+    "g.apply_greedy(250)\n",
+    "results = evaluate_graph(model, g, dataloader, partial(metric_fn, loss=False, mean=False), prune=True).mean().item()\n",
+    "baseline = evaluate_baseline(model, dataloader, partial(metric_fn, loss=False, mean=False)).mean().item()\n",
+    "print(f\"Faithfulness: {results / baseline}\")\n",
+    "g.to_pt(\"circuits/greater-than_prob_diff_ig.pt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_dataset = load_dataset('stas/openwebtext-10k', split='train')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "intervention_dataloader = DataLoader(mean_dataset['text'][:1000], batch_size=16)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Computing mean: 100%|██████████| 16/16 [00:02<00:00,  5.67it/s]\n",
+      "100%|██████████| 16/16 [00:02<00:00,  7.48it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Faithfulness: 0.95990070311505\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "results2 = evaluate_graph(model, g, dataloader, partial(metric_fn, loss=False, mean=False), prune=True, intervention='mean-positional', intervention_dataloader=dataloader).mean().item()\n",
+    "print(f\"Faithfulness: {results2 / baseline}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "othello",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Mean ablation is now available as a type of intervention in `evaluate_graph`! You can either do it non-positionally (averages over all positions), or positionally. But, in the latter case, you're in charge of ensuring that everything has the same length.