### PR TITLE
Greedy algorithm for information flow routes

### DIFF
--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -29,6 +29,8 @@ if __name__ == "__main__":
     parser.add_argument("--circuit-files", type=str, nargs='+', default=None)
     parser.add_argument("--output-dir", type=str, default='results')
     args = parser.parse_args()
+    
+    apply_greedy =  args.method in ["information-flow-routes"]#add your own method to the list if necessary
 
     i = 0
     for model_name in args.models:
@@ -78,8 +80,11 @@ if __name__ == "__main__":
             if model_name == "interpbench":
                 d = evaluate_area_under_roc(reference_graph, graph)
             else:
-                eval_auc_outputs = evaluate_area_under_curve(model, graph, dataloader, attribution_metric, level=args.level, 
-                                                            absolute=args.absolute)
+                eval_auc_outputs = evaluate_area_under_curve(
+                    model, graph, dataloader, attribution_metric, level=args.level,
+                    absolute=args.absolute,
+                    apply_greedy=apply_greedy,
+                )
                 weighted_edge_counts, area_under, area_from_1, average, faithfulnesses = eval_auc_outputs
                 d = {
                     "weighted_edge_counts": weighted_edge_counts,


### PR DESCRIPTION
Appendix D.2 in the arxiv paper states that
"Because important scores are normalized (for any given node, the sum of the scores of edges to it will be 1), we cannot apply a top-n procedure to find IFR circuits; we must use greedy search."

If I understand the code correctly, it implements a greedy search option, but currently doesn't call it by default for IFR. My commit should fix that.

What my commit does not fix is the Interpbench case. I haven't really thought about that, but it seems to be more difficult to fix (but I don't even know if a fix is necessary).