### PR TITLE
Two bug fixes

### DIFF
--- a/print_results.py
+++ b/print_results.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
         method_path = os.path.join(args.output_dir, method_name)
         for results_file in os.listdir(method_path):
             task, model, split, abs = os.path.splitext(results_file)[0].split("_")
-            if f"{task}_{model}" not in COL_MAPPING:
+            if (f"{task}_{model}" not in COL_MAPPING) or model=='interpbench':
                 continue
             if split != args.split:
                 continue

--- a/run_evaluation.py
+++ b/run_evaluation.py
@@ -97,5 +97,5 @@ if __name__ == "__main__":
             method_name_saveable = f"{args.method}_{args.ablation}_{args.level}"
             output_path = os.path.join(args.output_dir, method_name_saveable)
             os.makedirs(output_path, exist_ok=True)
-            with open(f"{output_path}/{task}_{model_name}_{args.split}_abs-{args.absolute}.pkl", 'wb') as f:
+            with open(f"{output_path}/{task.replace('_', '-')}_{model_name}_{args.split}_abs-{args.absolute}.pkl", 'wb') as f:
                 pickle.dump(d, f)


### PR DESCRIPTION
1. print_results.py expects that there is no underscore "_" within a task name, so I made run_evaluation.py to replace it with a minus "-" when saving.
2. When calling print_results.py with metric cpr or cmd, it should ignore all the interpbench stuff.